### PR TITLE
#43 feat: 이미지 업로드 컴포넌트 생성 및 이미지 서버에 저장

### DIFF
--- a/src/Components/CampReview/CampReview.jsx
+++ b/src/Components/CampReview/CampReview.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
+import ImageUpload from '../ImageUpload/ImageUpload';
 
-const CampReview = (props) => <div>review</div>;
+const CampReview = (props) => {
+  return (
+    <div>
+      <ImageUpload />
+    </div>
+  );
+};
 
 export default CampReview;

--- a/src/Components/ImageUpload/ImageUpload.jsx
+++ b/src/Components/ImageUpload/ImageUpload.jsx
@@ -1,0 +1,60 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+import { Button, Spin } from 'antd';
+import { UploadOutlined } from '@ant-design/icons';
+import { imageUploader } from '../../Service/imageUploder';
+
+const ImageUpload = () => {
+  const [loading, setLoading] = useState(false);
+
+  const inputRef = useRef();
+
+  const onbuttonClick = (event) => {
+    event.preventDefault();
+    inputRef.current.click();
+  };
+
+  const onChange = async (event) => {
+    console.log(event.target.files[0]);
+    setLoading(true);
+    const uploaded = await imageUploader(event.target.files[0]);
+    setLoading(false);
+
+    console.log(uploaded);
+    // onImageChange({
+    //   name: uploaded.original_filename,
+    //   url: uploaded.url,
+    // });
+  };
+  return (
+    <div>
+      <Input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        name="file"
+        onChange={onChange}
+      />
+
+      {!loading ? (
+        <ButtonContent onClick={onbuttonClick} icon={<UploadOutlined />}>
+          Click to Upload
+        </ButtonContent>
+      ) : (
+        <ButtonContent>
+          <Spin />
+        </ButtonContent>
+      )}
+    </div>
+  );
+};
+
+export default ImageUpload;
+
+const Input = styled.input`
+  display: none;
+`;
+
+const ButtonContent = styled(Button)`
+  width: 148px;
+`;

--- a/src/Service/imageUploder.js
+++ b/src/Service/imageUploder.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+export async function imageUploader(file) {
+  const form = new FormData();
+  form.append('file', file);
+  form.append('upload_preset', 'oxdsrfek');
+  const response = await axios(
+    'https://api.cloudinary.com/v1_1/divncmfka/image/upload',
+    {
+      method: 'POST',
+      data: form,
+    },
+  );
+  return response;
+}


### PR DESCRIPTION
<br/>
## 해당 이슈 📎

- issue title  #43 
  <br/>

## 변경 사항 🛠

 - 이미지 업로드 컴포넌트 구현 ( 앤트디자인의 Button 사용) 
 - 이미지 서버를 추가하여 이미지 서버 url을 response로 받아오도록 함 
 - 이미지가 업로드 되기 전 로딩스피너가 렌더링 


<br/>

## 리뷰어 참고 사항 🙋‍♀️
- 이미지 업로드 컴포넌트에 이미지 url을 받아오는 함수를 props로 넘겨주고 이미지업로드 컴포넌트 내에 onChange함수에서 호출하면 될 거 같습니다 !
<br/>
