### PR TITLE
#43 feature/imageUpload: 이미지 프리뷰 컴포넌트 기능 추가

### DIFF
--- a/src/Components/CampReview/CampReview.jsx
+++ b/src/Components/CampReview/CampReview.jsx
@@ -1,12 +1,43 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+import ImagePreview from '../ImageUpload/ImagePreview/ImagePreview';
 import ImageUpload from '../ImageUpload/ImageUpload';
 
 const CampReview = (props) => {
+  const [review, setReview] = useState({
+    rate: null,
+    text: '',
+    image: null,
+  });
+
+  const setImageUpload = useCallback((file, action) => {
+    if (action === 'add') {
+      setReview(() => {
+        return { ...review, image: file };
+      });
+    } else {
+      setReview(() => {
+        return { ...review, image: null };
+      });
+    }
+  }, []);
+
   return (
-    <div>
-      <ImageUpload />
-    </div>
+    <Container>
+      <ImageUpload setImageUpload={setImageUpload} />
+      {review.image !== null && (
+        <ImagePreview
+          setImageUpload={setImageUpload}
+          previewImg={review.image}
+        />
+      )}
+    </Container>
   );
 };
 
 export default CampReview;
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+`;

--- a/src/Components/ImageUpload/ImagePreview/ImagePreview.jsx
+++ b/src/Components/ImageUpload/ImagePreview/ImagePreview.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { style } from './ImagePreview.style';
+
+const ImagePreview = ({ setImageUpload, previewImg }) => {
+  console.log(previewImg);
+  return (
+    <Wrap>
+      <Image src={previewImg.url} alt="preview" />
+      <ImageName>{previewImg.name}</ImageName>
+      <CloseBtn onClick={setImageUpload}>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 12 12"
+          fill="black"
+          fillOpacity="0.6"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M6.92473 5.99916L11.6122 0.411663C11.6908 0.318806 11.6247 0.177734 11.5033 0.177734H10.0783C9.99437 0.177734 9.91401 0.215234 9.85865 0.27952L5.99258 4.88845L2.12651 0.27952C2.07294 0.215234 1.99258 0.177734 1.90687 0.177734H0.481867C0.360439 0.177734 0.294367 0.318806 0.372939 0.411663L5.06044 5.99916L0.372939 11.5867C0.355338 11.6074 0.344047 11.6327 0.340404 11.6596C0.336762 11.6865 0.340922 11.7139 0.352391 11.7386C0.36386 11.7632 0.382156 11.784 0.405107 11.7985C0.428057 11.8131 0.454698 11.8207 0.481867 11.8206H1.90687C1.9908 11.8206 2.07115 11.7831 2.12651 11.7188L5.99258 7.10988L9.85865 11.7188C9.91222 11.7831 9.99258 11.8206 10.0783 11.8206H11.5033C11.6247 11.8206 11.6908 11.6795 11.6122 11.5867L6.92473 5.99916Z" />
+        </svg>
+      </CloseBtn>
+    </Wrap>
+  );
+};
+
+export default ImagePreview;
+
+const { Wrap, Image, ImageName, CloseBtn } = style;

--- a/src/Components/ImageUpload/ImagePreview/ImagePreview.style.js
+++ b/src/Components/ImageUpload/ImagePreview/ImagePreview.style.js
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+const Wrap = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Image = styled.img`
+  width: 50px;
+  height: 50px;
+  margin-right: 10px;
+`;
+
+const ImageName = styled.span`
+  font-size: 14px;
+  width: 120px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  margin-right: 10px;
+`;
+
+const CloseBtn = styled.div`
+  cursor: pointer;
+`;
+
+export const style = {
+  Wrap,
+  Image,
+  ImageName,
+  CloseBtn,
+};

--- a/src/Components/ImageUpload/ImageUpload.jsx
+++ b/src/Components/ImageUpload/ImageUpload.jsx
@@ -4,9 +4,8 @@ import { Button, Spin } from 'antd';
 import { UploadOutlined } from '@ant-design/icons';
 import { imageUploader } from '../../Service/imageUploder';
 
-const ImageUpload = () => {
+const ImageUpload = ({ setImageUpload }) => {
   const [loading, setLoading] = useState(false);
-
   const inputRef = useRef();
 
   const onbuttonClick = (event) => {
@@ -20,14 +19,18 @@ const ImageUpload = () => {
     const uploaded = await imageUploader(event.target.files[0]);
     setLoading(false);
 
-    console.log(uploaded);
-    // onImageChange({
-    //   name: uploaded.original_filename,
-    //   url: uploaded.url,
-    // });
+    console.log(uploaded.data);
+    setImageUpload(
+      {
+        name: `${uploaded.data.original_filename}.${uploaded.data.format}`,
+        url: uploaded.data.url,
+      },
+      'add',
+    );
   };
+
   return (
-    <div>
+    <Wrap>
       <Input
         ref={inputRef}
         type="file"
@@ -45,11 +48,15 @@ const ImageUpload = () => {
           <Spin />
         </ButtonContent>
       )}
-    </div>
+    </Wrap>
   );
 };
 
 export default ImageUpload;
+
+const Wrap = styled.div`
+  margin-right: 20px;
+`;
 
 const Input = styled.input`
   display: none;


### PR DESCRIPTION
<br/>
## 해당 이슈 📎

- issue title  #43  
  <br/>

## 변경 사항 🛠

- 이미지 프리뷰 컴포넌트 생성 
- ImageUpload 컴포넌트와 ImagePreview 컴포넌트를 하나의 상위 컴포넌트에서 렌더링 
- X 버튼을 누르면 프리뷰 삭제
- 이미지 이름 정해진 width 넘어가면 밑줄 처리 



<br/>

## 리뷰어 참고 사항 🙋‍♀️
CampReview 컴포넌트가 현재는 ImageUpload 컴포넌트와 ImagePreview 컴포넌트의 상위 컴포넌트입니다 
CampReview 컴포넌트의 코드 그대로 가져가셔서 쓰시면 될 것 같습니다 👍
헷갈리는 부분 있으시면 말씀해주세요 !

<br/>
