### PR TITLE
fix: GithubAction npm deploy 대신 build로 변경하고 aws key 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,5 +20,18 @@ jobs:
 
       - run: echo "🏃‍♂️ start deploying! "
 
-      - name: Deploy
-        run: npm deploy
+      - name: Build
+        run: npm build:dev
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy to S3
+        run: aws s3 sync ./dist s3://${{ secrets.DEV_AWS_S3_BUCKET }} --delete
+
+      - name: Invalidate CloudFront Cache
+        run: aws cloudfront create-invalidation --distribution-id ${{secrets.DEV_AWS_DISTRIBUTION_ID}} --paths "/*"


### PR DESCRIPTION
<br/>

## 해당 이슈 📎

- issue title 

  <br/>

## 변경 사항 🛠

npm deploy로 build후 aws 자동배포하려 했던 기존 코드의 에러로 인해 아래와 같이 변경 했습니다. 

```
   steps:
      - name: Checkout source code.
        uses: actions/checkout@v2

      - run: echo "🏃‍♂️ start deploying! "

      - name: Build
        run: npm build:dev

      - name: Configure AWS Credentials
        uses: aws-actions/configure-aws-credentials@v1
        with:
          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
          aws-region: ${{ secrets.AWS_REGION }}

      - name: Deploy to S3
        run: aws s3 sync ./dist s3://${{ secrets.DEV_AWS_S3_BUCKET }} --delete

      - name: Invalidate CloudFront Cache
        run: aws cloudfront create-invalidation --distribution-id ${{secrets.DEV_AWS_DISTRIBUTION_ID}} --paths "/*"

```

<br/>

## 리뷰어 참고 사항 🙋‍♀️

- 참고사항 기재
  <br/>
