### PR TITLE
fix:  Build시 Warning을 Error로 인식하는 에러 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,4 @@ jobs:
       - run: echo "🏃‍♂️ start deploying! "
 
       - name: Build
-        run: npm run deploy
+        run: CI='' npm run deploy


### PR DESCRIPTION
<br/>

## 해당 이슈 📎

- issue title 

  <br/>

## 변경 사항 🛠

Build시 Warning을 Error로 인식하는 에러 발생 
"Treating warnings as errors because process.env.CI = true. Most CI servers set it automatically."
아래와 같이 CI를 추가해주면서 해결

```
      - name: Build
        run: CI='' npm run deploy

```


<br/>

## 리뷰어 참고 사항 🙋‍♀️


  <br/>
