### PR TITLE
fix:  ubuntu-latest에서 ubuntu-18.04로 번경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         node-versions: [14.x]


### PR DESCRIPTION
<br/>

## 해당 이슈 📎

  <br/>

## 변경 사항 🛠

ubuntu-20.04 로 변경되면서 aws-cli 명령어가 바뀐부분이 생겼습니다. 

때문에 기존 aws-cli 명령어가 작동하지 않은 것이었습니다. 

ubuntu-18.04 로 버전을 지정하여 해결하였습니다!

```
runs-on: ubuntu-18.04
```

<br/>

## 리뷰어 참고 사항 🙋‍♀️


  <br/>
